### PR TITLE
Missing init flip of boolean to have command stay alive for full arm move action

### DIFF
--- a/smokey/src/main/java/frc/robot/commands/ArmToExtensionsCommand.java
+++ b/smokey/src/main/java/frc/robot/commands/ArmToExtensionsCommand.java
@@ -56,6 +56,7 @@ public class ArmToExtensionsCommand extends CommandBase {
 
     @Override
     public void initialize() {
+        done = false;
         this.armSubsystem.setArmExtensions(horizontalExtensionValue, verticalExtensionValue);
     }
 


### PR DESCRIPTION
Missing init flip of boolean to have command stay alive for full arm move action