### PR TITLE
Second order swerve fix

### DIFF
--- a/smokey/shuffleboard/BearMaxShuffleBoard.json
+++ b/smokey/shuffleboard/BearMaxShuffleBoard.json
@@ -162,45 +162,6 @@
               "Colors/Color when true": "#7CFC00FF",
               "Colors/Color when false": "#8B0000FF"
             }
-          },
-          "9,2": {
-            "size": [
-              2,
-              1
-            ],
-            "content": {
-              "_type": "Command",
-              "_source0": "network_table:///SmartDashboard/Drive Forward at high speed med rotation",
-              "_title": "SmartDashboard/Drive Forward at high speed med rotation",
-              "_glyph": 148,
-              "_showGlyph": false
-            }
-          },
-          "9,3": {
-            "size": [
-              2,
-              1
-            ],
-            "content": {
-              "_type": "Command",
-              "_source0": "network_table:///SmartDashboard/Drive Forward at high speed large rotation",
-              "_title": "SmartDashboard/Drive Forward at high speed large rotation",
-              "_glyph": 148,
-              "_showGlyph": false
-            }
-          },
-          "9,1": {
-            "size": [
-              2,
-              1
-            ],
-            "content": {
-              "_type": "Command",
-              "_source0": "network_table:///SmartDashboard/Drive Forward at high speed no rotation",
-              "_title": "SmartDashboard/Drive Forward at high speed no rotation",
-              "_glyph": 148,
-              "_showGlyph": false
-            }
           }
         }
       }
@@ -355,7 +316,7 @@
   "windowGeometry": {
     "x": -7.0,
     "y": 0.0,
-    "width": 1929.0,
+    "width": 1519.0,
     "height": 836.0
   }
 }

--- a/smokey/shuffleboard/BearMaxShuffleBoard.json
+++ b/smokey/shuffleboard/BearMaxShuffleBoard.json
@@ -162,6 +162,45 @@
               "Colors/Color when true": "#7CFC00FF",
               "Colors/Color when false": "#8B0000FF"
             }
+          },
+          "9,2": {
+            "size": [
+              2,
+              1
+            ],
+            "content": {
+              "_type": "Command",
+              "_source0": "network_table:///SmartDashboard/Drive Forward at high speed med rotation",
+              "_title": "SmartDashboard/Drive Forward at high speed med rotation",
+              "_glyph": 148,
+              "_showGlyph": false
+            }
+          },
+          "9,3": {
+            "size": [
+              2,
+              1
+            ],
+            "content": {
+              "_type": "Command",
+              "_source0": "network_table:///SmartDashboard/Drive Forward at high speed large rotation",
+              "_title": "SmartDashboard/Drive Forward at high speed large rotation",
+              "_glyph": 148,
+              "_showGlyph": false
+            }
+          },
+          "9,1": {
+            "size": [
+              2,
+              1
+            ],
+            "content": {
+              "_type": "Command",
+              "_source0": "network_table:///SmartDashboard/Drive Forward at high speed no rotation",
+              "_title": "SmartDashboard/Drive Forward at high speed no rotation",
+              "_glyph": 148,
+              "_showGlyph": false
+            }
           }
         }
       }

--- a/smokey/shuffleboard/BearMaxShuffleBoard.json
+++ b/smokey/shuffleboard/BearMaxShuffleBoard.json
@@ -316,7 +316,7 @@
   "windowGeometry": {
     "x": -7.0,
     "y": 0.0,
-    "width": 1519.0,
+    "width": 1929.0,
     "height": 836.0
   }
 }

--- a/smokey/src/main/java/frc/robot/RobotContainer.java
+++ b/smokey/src/main/java/frc/robot/RobotContainer.java
@@ -92,35 +92,8 @@ public class RobotContainer {
     SmartDashboard.putData("Drive Forward with rotation", 
       new DriveTimeCommand(this.subsystems.getDriveTrainSubsystem(), 
       new ChassisSpeeds(0.6, 0.0, 0.2), 3.0));
-    SmartDashboard.putData("Arms to reference position", 
-      new ArmToReferencePositionCommand(this.subsystems.getArmSubsystem()));
     SmartDashboard.putData("Print NavX State", 
       new InstantCommand(this.subsystems.getDriveTrainSubsystem()::printState));
-    // commands to test lateral drift while rotating
-    SmartDashboard.putData("Drive Forward at high speed no rotation", 
-    new DriveTimeCommand(
-      this.subsystems.getDriveTrainSubsystem(), 
-      new ChassisSpeeds(0.8 * DrivetrainSubsystem.MAX_VELOCITY_METERS_PER_SECOND, 
-      0.0 * DrivetrainSubsystem.MAX_VELOCITY_METERS_PER_SECOND, 
-      0.0 * DrivetrainSubsystem.MAX_ANGULAR_VELOCITY_RADIANS_PER_SECOND),
-      1.5, 
-      true));
-    SmartDashboard.putData("Drive Forward at high speed med rotation", 
-    new DriveTimeCommand(
-      this.subsystems.getDriveTrainSubsystem(), 
-      new ChassisSpeeds(0.8 * DrivetrainSubsystem.MAX_VELOCITY_METERS_PER_SECOND, 
-      0.0 * DrivetrainSubsystem.MAX_VELOCITY_METERS_PER_SECOND, 
-      0.25 * DrivetrainSubsystem.MAX_ANGULAR_VELOCITY_RADIANS_PER_SECOND),
-      1.5,
-      true));
-    SmartDashboard.putData("Drive Forward at high speed large rotation", 
-    new DriveTimeCommand(
-      this.subsystems.getDriveTrainSubsystem(), 
-      new ChassisSpeeds(0.8 * DrivetrainSubsystem.MAX_VELOCITY_METERS_PER_SECOND, 
-      0.0 * DrivetrainSubsystem.MAX_VELOCITY_METERS_PER_SECOND, 
-      0.5 * DrivetrainSubsystem.MAX_ANGULAR_VELOCITY_RADIANS_PER_SECOND),
-      1.5,
-      true));
   }
  
   /**

--- a/smokey/src/main/java/frc/robot/RobotContainer.java
+++ b/smokey/src/main/java/frc/robot/RobotContainer.java
@@ -94,6 +94,13 @@ public class RobotContainer {
       new ArmToReferencePositionCommand(this.subsystems.getArmSubsystem()));
     SmartDashboard.putData("Print NavX State", 
       new InstantCommand(this.subsystems.getDriveTrainSubsystem()::printState));
+    // commands to test lateral drift while rotating
+    SmartDashboard.putData("Drive Forward at high speed no rotation", 
+    new DriveTimeCommand(this.subsystems.getDriveTrainSubsystem(), 0.9, 0.0, 0.0, 2.0));
+    SmartDashboard.putData("Drive Forward at high speed med rotation", 
+    new DriveTimeCommand(this.subsystems.getDriveTrainSubsystem(), 0.9, 0.0, 0.25, 2.0));
+    SmartDashboard.putData("Drive Forward at high speed large rotation", 
+    new DriveTimeCommand(this.subsystems.getDriveTrainSubsystem(), 0.9, 0.0, 0.5, 2.0));
   }
  
   /**

--- a/smokey/src/main/java/frc/robot/RobotContainer.java
+++ b/smokey/src/main/java/frc/robot/RobotContainer.java
@@ -87,20 +87,43 @@ public class RobotContainer {
 
     // Command to drive the chassis for zeroing the swerve modules.
     SmartDashboard.putData("Drive Forward Robot Centric", 
-      new DriveTimeCommand(this.subsystems.getDriveTrainSubsystem(), 0.6, 0.0, 0.0, 3.0));
+      new DriveTimeCommand(this.subsystems.getDriveTrainSubsystem(), 
+      new ChassisSpeeds(0.6, 0.0, 0.0), 3.0));
     SmartDashboard.putData("Drive Forward with rotation", 
-      new DriveTimeCommand(this.subsystems.getDriveTrainSubsystem(), 0.6, 0.0, 0.2, 3.0));
+      new DriveTimeCommand(this.subsystems.getDriveTrainSubsystem(), 
+      new ChassisSpeeds(0.6, 0.0, 0.2), 3.0));
     SmartDashboard.putData("Arms to reference position", 
       new ArmToReferencePositionCommand(this.subsystems.getArmSubsystem()));
     SmartDashboard.putData("Print NavX State", 
       new InstantCommand(this.subsystems.getDriveTrainSubsystem()::printState));
     // commands to test lateral drift while rotating
     SmartDashboard.putData("Drive Forward at high speed no rotation", 
-    new DriveTimeCommand(this.subsystems.getDriveTrainSubsystem(), 0.9, 0.0, 0.0, 2.0));
+    new DriveTimeCommand(
+      this.subsystems.getDriveTrainSubsystem(), 
+      ChassisSpeeds.fromFieldRelativeSpeeds(
+        new ChassisSpeeds(0.8 * DrivetrainSubsystem.MAX_VELOCITY_METERS_PER_SECOND, 
+        0.0 * DrivetrainSubsystem.MAX_VELOCITY_METERS_PER_SECOND, 
+        0.0 * DrivetrainSubsystem.MAX_ANGULAR_VELOCITY_RADIANS_PER_SECOND),
+        this.subsystems.getDriveTrainSubsystem().getGyroscopeRotation()), 
+      1.5));
     SmartDashboard.putData("Drive Forward at high speed med rotation", 
-    new DriveTimeCommand(this.subsystems.getDriveTrainSubsystem(), 0.9, 0.0, 0.25, 2.0));
+    new DriveTimeCommand(
+      this.subsystems.getDriveTrainSubsystem(), 
+      ChassisSpeeds.fromFieldRelativeSpeeds(
+        new ChassisSpeeds(0.8 * DrivetrainSubsystem.MAX_VELOCITY_METERS_PER_SECOND, 
+        0.0 * DrivetrainSubsystem.MAX_VELOCITY_METERS_PER_SECOND, 
+        0.25 * DrivetrainSubsystem.MAX_ANGULAR_VELOCITY_RADIANS_PER_SECOND),
+        this.subsystems.getDriveTrainSubsystem().getGyroscopeRotation()), 
+      1.5));
     SmartDashboard.putData("Drive Forward at high speed large rotation", 
-    new DriveTimeCommand(this.subsystems.getDriveTrainSubsystem(), 0.9, 0.0, 0.5, 2.0));
+    new DriveTimeCommand(
+      this.subsystems.getDriveTrainSubsystem(), 
+      ChassisSpeeds.fromFieldRelativeSpeeds(
+        new ChassisSpeeds(0.8 * DrivetrainSubsystem.MAX_VELOCITY_METERS_PER_SECOND, 
+        0.0 * DrivetrainSubsystem.MAX_VELOCITY_METERS_PER_SECOND, 
+        0.5 * DrivetrainSubsystem.MAX_ANGULAR_VELOCITY_RADIANS_PER_SECOND),
+        this.subsystems.getDriveTrainSubsystem().getGyroscopeRotation()), 
+      1.5));
   }
  
   /**

--- a/smokey/src/main/java/frc/robot/commands/DriveTimeCommand.java
+++ b/smokey/src/main/java/frc/robot/commands/DriveTimeCommand.java
@@ -19,9 +19,7 @@ public class DriveTimeCommand extends CommandBase
   private DrivetrainSubsystem drivetrain;
   private Timer timer = new Timer();
   private boolean done = false;
-  private double xVelocity = 0.0;
-  private double yVelocity = 0.0;
-  private double rotVelocity = 0.0;
+  private ChassisSpeeds chassisSpeeds = new ChassisSpeeds();
   private double durationSecondsValue = 0.0;
   
   /** 
@@ -33,18 +31,14 @@ public class DriveTimeCommand extends CommandBase
   */
   public DriveTimeCommand(
     DrivetrainSubsystem drivetrainSubsystem,
-    double x,
-    double y,
-    double rot,
+    ChassisSpeeds chassisSpeeds,
     double durationSeconds)
   {
     // Use addRequirements() here to declare subsystem dependencies.
     this.drivetrain = drivetrainSubsystem;
     addRequirements(drivetrainSubsystem);
+    this.chassisSpeeds = chassisSpeeds;
 
-    xVelocity = x;
-    yVelocity = y;
-    rotVelocity = rot;
     durationSecondsValue = durationSeconds;
   }
 
@@ -62,8 +56,7 @@ public class DriveTimeCommand extends CommandBase
   @Override
   public void execute()
   {
-    drivetrain.drive(
-      new ChassisSpeeds(xVelocity, yVelocity, rotVelocity));
+    drivetrain.drive(chassisSpeeds);
     if (timer.hasElapsed(this.durationSecondsValue))
     {
       done = true;

--- a/smokey/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
+++ b/smokey/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
@@ -788,7 +788,8 @@ public class DrivetrainSubsystem extends SubsystemBase {
       theLock.unlock();
     }
 
-    SmartDashboard.putNumber("RobotFieldHeadingDegrees", this.getGyroscopeRotation().getDegrees() );//currentPosition.getRotation().getDegrees());
+    SmartDashboard.putNumber("RobotFieldHeadingDegrees", this.getGyroscopeRotation().getDegrees() );
+    // getGyroscopeRotation() should be the same as currentPosition.getRotation after one call to swerveOdometry.update in periodic
     SmartDashboard.putNumber("RobotFieldXCoordinateMeters", currentPosition.getX());
     SmartDashboard.putNumber("RobotFieldYCoordinateMeters", currentPosition.getY());
     SmartDashboard.putNumber("RobotPitchDegrees", this.getEulerAngle().getPitch());

--- a/smokey/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
+++ b/smokey/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
@@ -788,7 +788,7 @@ public class DrivetrainSubsystem extends SubsystemBase {
       theLock.unlock();
     }
 
-    SmartDashboard.putNumber("RobotFieldHeadingDegrees", currentPosition.getRotation().getDegrees());
+    SmartDashboard.putNumber("RobotFieldHeadingDegrees", this.getGyroscopeRotation().getDegrees() );//currentPosition.getRotation().getDegrees());
     SmartDashboard.putNumber("RobotFieldXCoordinateMeters", currentPosition.getX());
     SmartDashboard.putNumber("RobotFieldYCoordinateMeters", currentPosition.getY());
     SmartDashboard.putNumber("RobotPitchDegrees", this.getEulerAngle().getPitch());

--- a/smokey/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
+++ b/smokey/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
@@ -630,6 +630,7 @@ public class DrivetrainSubsystem extends SubsystemBase {
       (twist.dx / deltaTimeSeconds), 
       (twist.dy / deltaTimeSeconds), 
       (speeds.omegaRadiansPerSecond));
+    // return(speeds);
   }
 
 


### PR DESCRIPTION
Compensate for lateral drift while rotating.  Adds a discretize function to DrivetrainSubsystem for correcting chassisSpeeds.  Time scale factor found empirically via testing on robot driving a straight line forward for ~10ft with a 25% rotation, and measuring the lateral offset.  Remaining error is approximately 1' lateral error over ~10f driving distance. 